### PR TITLE
Fills in background of main window

### DIFF
--- a/src/vue-app/index.scss
+++ b/src/vue-app/index.scss
@@ -15,3 +15,9 @@
 		display: none;
 	}
 }
+
+body{
+	/* Fills in background of main window */
+	background-color: $background-color;
+	height: auto;
+}


### PR DESCRIPTION
When running the app the #app div showed the background color but the rest of the window was the default grey/black. Adding style to the Body tag makes the whole window the same background color.

Before style is added
![electron-vue-boilerplate](https://user-images.githubusercontent.com/8809376/107399531-6d9ce600-6ac6-11eb-9ca1-8f48e7c8515b.png)

After style is added
![electron-vue-boilerplate-update](https://user-images.githubusercontent.com/8809376/107399805-c66c7e80-6ac6-11eb-88f9-04efedbe809c.png)


